### PR TITLE
fix: replace runNum with runId in action run url

### DIFF
--- a/src/message-card.ts
+++ b/src/message-card.ts
@@ -33,7 +33,7 @@ export function createMessageCard(
       }
     ],
     potentialAction: [
-      createAction('View Workflow Run', `${repoUrl}/actions/runs/${runNum}`),
+      createAction('View Workflow Run', `${repoUrl}/actions/runs/${runId}`),
       createAction('View Commit Changes', commit.data.html_url)
     ]
   }


### PR DESCRIPTION
just a guess. but the URLs are not working. seems like it is not the runNum. so I tried it with RunId... if you happen to be able to try this locally, please do :)